### PR TITLE
Update dependencies and convert to ES module

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ returned as promises:
 ```javascript
 // Call the Contact.get API for contact #100. Return a promise.
 
-var cv = require('civicrm-cv')({mode: 'promise'});
+import {default as cvFactory} from 'civicrm-cv';
+const cv = cvFactory({'mode':'promise'});
+
 cv('api contact.get id=100').then(function(result){
   console.log("Found records: " + result.count);
 });
@@ -41,7 +43,9 @@ Alternatively, you may execute subcommands synchronously:
 ```javascript
 // Lookup the general site metadata. Return the data synchronously (blocking I/O).
 
-var cv = require('civicrm-cv')({mode: 'sync'});
+import {default as cvFactory} from 'civicrm-cv';
+const cv = cvFactory({'mode':'sync'});
+
 var result = cv('vars:show');
 console.log("The Civi database is " + result.CIVI_DB_DSN);
 console.log("The CMS database is " + result.CMS_DB_DSN);
@@ -58,7 +62,9 @@ involves passing unusual characters, e.g.
 ```javascript
 // Execute a small fragment of PHP code. Return the data synchronously (blocking I/O).
 
-var cv = require('civicrm-cv')({mode: 'sync'});
+import {default as cvFactory} from 'civicrm-cv';
+const cv = cvFactory({'mode':'sync'});
+
 var result = cv(['php:eval', '$x = 2; return [$x * $x];']);
 console.log("Received value: " + result);
 ```

--- a/civicrm-cv.js
+++ b/civicrm-cv.js
@@ -1,4 +1,5 @@
-import {execa} from 'execa';
+const { execa } = await import("execa");
+
 function execPromise(cmd, options) {
   return execa(options)`${cmd}`;
 }
@@ -29,7 +30,7 @@ var jsonExecFuncs = {
   }
 };
 
-module.exports = function(options) {
+export default function(options) {
   if (!options || options.mode === undefined) {
     throw "civicrm-cv: Please specify \'mode\' option.";
   }

--- a/civicrm-cv.js
+++ b/civicrm-cv.js
@@ -1,12 +1,7 @@
-const { execa } = await import("execa");
+import {execa as execPromise} from 'execa';
+import {execSync} from 'child_process';
 
-function execPromise(cmd, options) {
-  return execa(options)`${cmd}`;
-}
-
-const execSync = require('child_process').execSync;
-
-var escape = function(cmd) {
+function escape(cmd) {
   return '\'' + cmd.replace(/'/g, "'\\''") + '\'';
 };
 
@@ -18,13 +13,24 @@ function serializeArgs(args) {
   return argsStr;
 }
 
+function serializeCommand(cmd, args) {
+  if (typeof args === 'string') {
+    return  cmd + ' ' + args;
+  }
+  else {
+    return cmd + serializeArgs(args);
+  }
+}
+
 var jsonExecFuncs = {
-  sync: function jsonExecSync(cmd, env) {
+  sync: function jsonExecSync(cmd, args, env) {
+    cmd = serializeCommand(cmd, args)
     var result = execSync(cmd, {env: env});
     return JSON.parse(result.toString());
   },
-  promise: function jsonExecPromise(cmd, env) {
-    return execPromise(cmd, {env: env}).then(function(result) {
+  promise: function jsonExecPromise(cmd, args, env) {
+    args = (typeof args === 'string') ? [args] : args;
+    return execPromise(cmd, args, {env: env}).then(function(result) {
       return JSON.parse(result.stdout);
     });
   }
@@ -38,14 +44,8 @@ export default function(options) {
     throw "civicrm-cv: Invalid \'mode\' option";
   }
 
-  return function(subcommand) {
-    var cmd;
-    if (typeof subcommand === 'string') {
-      cmd = 'cv ' + subcommand;
-    }
-    else {
-      cmd = 'cv' + serializeArgs(subcommand);
-    }
+  return function(args) {
+    const cmd = 'cv';
 
     var env = {};
     for (var key in process.env) {
@@ -53,6 +53,6 @@ export default function(options) {
     }
     env.CV_OUTPUT = 'json';
 
-    return jsonExecFuncs[options.mode].apply(null, [cmd, env]);
+    return jsonExecFuncs[options.mode].apply(null, [cmd, args, env]);
   };
 };

--- a/civicrm-cv.js
+++ b/civicrm-cv.js
@@ -1,5 +1,9 @@
-var execPromise = require('child-process-promise').exec;
-var execSync = require('child_process').execSync;
+import {execa} from 'execa';
+function execPromise(cmd, options) {
+  return execa(options)`${cmd}`;
+}
+
+const execSync = require('child_process').execSync;
 
 var escape = function(cmd) {
   return '\'' + cmd.replace(/'/g, "'\\''") + '\'';

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/civicrm/cv-nodejs#readme",
   "dependencies": {
-    "child-process-promise": "^2.1.3"
+    "execa": "^9.6.0"
   },
   "devDependencies": {
     "jasmine-node": "^1.14.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "civicrm-cv",
-  "version": "0.1.2",
+  "type": "module",
+  "version": "0.2.0",
   "description": "Client library for accessing the cv command",
   "main": "civicrm-cv.js",
   "scripts": {


### PR DESCRIPTION
Some dependencies had security vulnerabilities, and ES modules are now the standard.